### PR TITLE
feat: tokyo-tyrant tdd example

### DIFF
--- a/src/main/java/com/example/cleancoder/tdd/tyrant/TyrantMap.java
+++ b/src/main/java/com/example/cleancoder/tdd/tyrant/TyrantMap.java
@@ -1,0 +1,70 @@
+package com.example.cleancoder.tdd.tyrant;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+public class TyrantMap {
+    public static final int OPERATION_PREFIX = 0xC8;
+    public static final int OPERATION_PUT = 0x10;
+    public static final int OPERATION_GET = 0x30;
+
+    private Socket socket;
+    private DataOutputStream writer;
+    private DataInputStream reader;
+
+    public void put(String key, String value) throws IOException {
+        writeHeader(OPERATION_PUT);
+        writeKeyValue(key, value);
+        verifyStatus();
+    }
+
+    public void open() throws IOException {
+        socket = new Socket("localhost", 1978);
+        writer = new DataOutputStream(socket.getOutputStream());
+        reader = new DataInputStream(socket.getInputStream());
+    }
+
+    public byte[] get(String key) throws IOException {
+        writeHeader(OPERATION_GET);
+        writeKey(key);
+        verifyStatus();
+        return readResults();
+    }
+
+    public void close() throws IOException {
+        reader.close();
+        writer.close();
+        socket.close();
+    }
+
+    private void writeKey(String key) throws IOException {
+        writer.writeInt(key.length());
+        writer.write(key.getBytes());
+    }
+
+    private void writeHeader(int operationCode) throws IOException {
+        writer.write(OPERATION_PREFIX);
+        writer.write(operationCode);
+    }
+
+    private void writeKeyValue(String key, String value) throws IOException {
+        writer.writeInt(key.length());
+        writer.writeInt(value.length());
+        writer.write(key.getBytes());
+        writer.write(value.getBytes());
+    }
+
+    private void verifyStatus() throws IOException {
+        int status = reader.read();
+        assert status == 0;
+    }
+
+    private byte[] readResults() throws IOException {
+        int length = reader.readInt();
+        byte[] results = new byte[length];
+        reader.read(results);
+        return results;
+    }
+}

--- a/src/test/java/com/example/cleancoder/tdd/tyrant/TyrantMapTest.java
+++ b/src/test/java/com/example/cleancoder/tdd/tyrant/TyrantMapTest.java
@@ -1,0 +1,18 @@
+package com.example.cleancoder.tdd.tyrant;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class TyrantMapTest {
+
+    @Test
+    void getRetrievesWhatWasPut() throws IOException {
+        TyrantMap tyrantMap = new TyrantMap();
+        tyrantMap.open();
+        tyrantMap.put("key", "value");
+        assertThat(tyrantMap.get("key")).isEqualTo("value".getBytes());
+        tyrantMap.close();
+    }
+}


### PR DESCRIPTION
- tokyo-tyrant 서버 실행해서 key, value 형식으로 데이터 저장 후 조회
  - 10년전 자료라 공식 서버에서 파일 다운로드 불가
  - 아래의 저장소를 내려 받아 설치 후 실행
  - https://github.com/msbaek/tyrant-client-tdd   
- 절차적인 실행 코드를 리팩터링
  - 1. inner class 추출
  - 2. 로컬 변수를 멤버 변수로 이동
  - 3. 메서드 추출
  - 4. 변수 인라인
  - 5. 로컬 변수를 매개변수로 전환
  - 6. 상위 클래스로 추출

메서드 추출하기 전 서로 다른 값을 가지는 파라미터에 대해 변수를 추출한 후 메서드 추출하는 게 인상적.
클래스 내에서 public 을 위에 두고, private을 아래에 두는 것도 인상적. 
