### PR TITLE
Lift up conditionals

### DIFF
--- a/src/main/java/com/example/cleancoder/liftupconditionals/AgedBrie.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/AgedBrie.java
@@ -1,0 +1,20 @@
+package com.example.cleancoder.liftupconditionals;
+
+public class AgedBrie extends Item {
+    public AgedBrie(int sellIn, int quality) {
+        super("Aged Brie", sellIn, quality);
+    }
+
+    @Override
+    protected void updateQuality() {
+        if (quality < 50) {
+            quality = quality + 1;
+        }
+
+        sellIn = sellIn - 1;
+
+        if (sellIn < 0 && quality < 50) {
+            quality = quality + 1;
+        }
+    }
+}

--- a/src/main/java/com/example/cleancoder/liftupconditionals/Backsage.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/Backsage.java
@@ -1,0 +1,28 @@
+package com.example.cleancoder.liftupconditionals;
+
+public class Backsage extends Item {
+    public Backsage(int sellIn, int quality) {
+        super("Backstage passes to a TAFKAL80ETC concert", sellIn, quality);
+    }
+
+    @Override
+    protected void updateQuality() {
+        if (quality < 50) {
+            quality = quality + 1;
+
+            if (sellIn < 11 && quality < 50) {
+                quality = quality + 1;
+            }
+
+            if (sellIn < 6 && quality < 50) {
+                quality = quality + 1;
+            }
+        }
+
+        sellIn = sellIn - 1;
+
+        if (sellIn < 0) {
+            quality = 0;
+        }
+    }
+}

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -12,55 +12,7 @@ public class GildedRose {
 
     public void updateQuality() {
         for (Item item : items) {
-            updateQualityFor(item);
-        }
-    }
-
-    private void updateQualityFor(Item item) {
-        if(item.name.equals("Sulfuras, Hand of Ragnaros")) {
-
-        } else {
-            if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                if (item.quality < 50) {
-                    item.quality = item.quality + 1;
-
-                    if (item.sellIn < 11 && item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
-
-                    if (item.sellIn < 6 && item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
-                }
-
-                item.sellIn = item.sellIn - 1;
-
-                if (item.sellIn < 0) {
-                    item.quality = 0;
-                }
-            } else {
-                if(item.name.equals("Aged Brie")) {
-                    if (item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
-
-                    item.sellIn = item.sellIn - 1;
-
-                    if (item.sellIn < 0 && item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
-                } else {
-                    if (item.quality > 0) {
-                        item.quality = item.quality - 1;
-                    }
-
-                    item.sellIn = item.sellIn - 1;
-
-                    if (item.sellIn < 0 && item.quality > 0) {
-                        item.quality = item.quality - 1;
-                    }
-                }
-            }
+            item.updateQuality();
         }
     }
 

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -17,39 +17,40 @@ public class GildedRose {
     }
 
     private void updateQualityFor(Item item) {
-        if (!item.name.equals("Aged Brie")
-                && !item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-            if (item.quality > 0) {
-                if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                    item.quality = item.quality - 1;
-                }
-            }
-        } else {
+        if(item.name.equals("Aged Brie")) {
             if (item.quality < 50) {
                 item.quality = item.quality + 1;
+            }
 
-                if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                    if (item.sellIn < 11) {
-                        if (item.quality < 50) {
-                            item.quality = item.quality + 1;
-                        }
+            item.sellIn = item.sellIn - 1;
+
+            if (item.sellIn < 0 && item.quality < 50) {
+                item.quality = item.quality + 1;
+            }
+        } else {
+            if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                if (item.quality > 0 && !item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                    item.quality = item.quality - 1;
+                }
+            } else {
+                if (item.quality < 50) {
+                    item.quality = item.quality + 1;
+
+                    if (item.sellIn < 11 && item.quality < 50) {
+                        item.quality = item.quality + 1;
                     }
 
-                    if (item.sellIn < 6) {
-                        if (item.quality < 50) {
-                            item.quality = item.quality + 1;
-                        }
+                    if (item.sellIn < 6 && item.quality < 50) {
+                        item.quality = item.quality + 1;
                     }
                 }
             }
-        }
 
-        if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-            item.sellIn = item.sellIn - 1;
-        }
+            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                item.sellIn = item.sellIn - 1;
+            }
 
-        if (item.sellIn < 0) {
-            if (!item.name.equals("Aged Brie")) {
+            if (item.sellIn < 0) {
                 if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
                     if (item.quality > 0) {
                         if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
@@ -57,13 +58,10 @@ public class GildedRose {
                         }
                     }
                 } else {
-                    item.quality = item.quality - item.quality;
-                }
-            } else {
-                if (item.quality < 50) {
-                    item.quality = item.quality + 1;
+                    item.quality = 0;
                 }
             }
         }
     }
+
 }

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -17,46 +17,48 @@ public class GildedRose {
     }
 
     private void updateQualityFor(Item item) {
-        if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-            if (item.quality < 50) {
-                item.quality = item.quality + 1;
+        if(item.name.equals("Sulfuras, Hand of Ragnaros")) {
 
-                if (item.sellIn < 11 && item.quality < 50) {
-                    item.quality = item.quality + 1;
-                }
-
-                if (item.sellIn < 6 && item.quality < 50) {
-                    item.quality = item.quality + 1;
-                }
-            }
-
-            item.sellIn = item.sellIn - 1;
-
-            if (item.sellIn < 0) {
-                item.quality = 0;
-            }
         } else {
-            if(item.name.equals("Aged Brie")) {
+            if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
                 if (item.quality < 50) {
                     item.quality = item.quality + 1;
+
+                    if (item.sellIn < 11 && item.quality < 50) {
+                        item.quality = item.quality + 1;
+                    }
+
+                    if (item.sellIn < 6 && item.quality < 50) {
+                        item.quality = item.quality + 1;
+                    }
                 }
 
                 item.sellIn = item.sellIn - 1;
 
-                if (item.sellIn < 0 && item.quality < 50) {
-                    item.quality = item.quality + 1;
+                if (item.sellIn < 0) {
+                    item.quality = 0;
                 }
             } else {
-                if (item.quality > 0 && !item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                    item.quality = item.quality - 1;
-                }
+                if(item.name.equals("Aged Brie")) {
+                    if (item.quality < 50) {
+                        item.quality = item.quality + 1;
+                    }
 
-                if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
                     item.sellIn = item.sellIn - 1;
-                }
 
-                if (item.sellIn < 0 && item.quality > 0 && !item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                    item.quality = item.quality - 1;
+                    if (item.sellIn < 0 && item.quality < 50) {
+                        item.quality = item.quality + 1;
+                    }
+                } else {
+                    if (item.quality > 0) {
+                        item.quality = item.quality - 1;
+                    }
+
+                    item.sellIn = item.sellIn - 1;
+
+                    if (item.sellIn < 0 && item.quality > 0) {
+                        item.quality = item.quality - 1;
+                    }
                 }
             }
         }

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -17,48 +17,46 @@ public class GildedRose {
     }
 
     private void updateQualityFor(Item item) {
-        if(item.name.equals("Aged Brie")) {
+        if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
             if (item.quality < 50) {
                 item.quality = item.quality + 1;
+
+                if (item.sellIn < 11 && item.quality < 50) {
+                    item.quality = item.quality + 1;
+                }
+
+                if (item.sellIn < 6 && item.quality < 50) {
+                    item.quality = item.quality + 1;
+                }
             }
 
             item.sellIn = item.sellIn - 1;
 
-            if (item.sellIn < 0 && item.quality < 50) {
-                item.quality = item.quality + 1;
+            if (item.sellIn < 0) {
+                item.quality = 0;
             }
         } else {
-            if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+            if(item.name.equals("Aged Brie")) {
+                if (item.quality < 50) {
+                    item.quality = item.quality + 1;
+                }
+
+                item.sellIn = item.sellIn - 1;
+
+                if (item.sellIn < 0 && item.quality < 50) {
+                    item.quality = item.quality + 1;
+                }
+            } else {
                 if (item.quality > 0 && !item.name.equals("Sulfuras, Hand of Ragnaros")) {
                     item.quality = item.quality - 1;
                 }
-            } else {
-                if (item.quality < 50) {
-                    item.quality = item.quality + 1;
 
-                    if (item.sellIn < 11 && item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
-
-                    if (item.sellIn < 6 && item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
+                if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                    item.sellIn = item.sellIn - 1;
                 }
-            }
 
-            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                item.sellIn = item.sellIn - 1;
-            }
-
-            if (item.sellIn < 0) {
-                if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                    if (item.quality > 0) {
-                        if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                            item.quality = item.quality - 1;
-                        }
-                    }
-                } else {
-                    item.quality = 0;
+                if (item.sellIn < 0 && item.quality > 0 && !item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                    item.quality = item.quality - 1;
                 }
             }
         }

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -11,52 +11,52 @@ public class GildedRose {
     }
 
     public void updateQuality() {
-        for (int i = 0; i < items.length; i++) {
-            if (!items[i].name.equals("Aged Brie")
-                    && !items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                if (items[i].quality > 0) {
-                    if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                        items[i].quality = items[i].quality - 1;
+        for (Item item : items) {
+            if (!item.name.equals("Aged Brie")
+                    && !item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                if (item.quality > 0) {
+                    if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                        item.quality = item.quality - 1;
                     }
                 }
             } else {
-                if (items[i].quality < 50) {
-                    items[i].quality = items[i].quality + 1;
+                if (item.quality < 50) {
+                    item.quality = item.quality + 1;
 
-                    if (items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (items[i].sellIn < 11) {
-                            if (items[i].quality < 50) {
-                                items[i].quality = items[i].quality + 1;
+                    if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                        if (item.sellIn < 11) {
+                            if (item.quality < 50) {
+                                item.quality = item.quality + 1;
                             }
                         }
 
-                        if (items[i].sellIn < 6) {
-                            if (items[i].quality < 50) {
-                                items[i].quality = items[i].quality + 1;
+                        if (item.sellIn < 6) {
+                            if (item.quality < 50) {
+                                item.quality = item.quality + 1;
                             }
                         }
                     }
                 }
             }
 
-            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                items[i].sellIn = items[i].sellIn - 1;
+            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                item.sellIn = item.sellIn - 1;
             }
 
-            if (items[i].sellIn < 0) {
-                if (!items[i].name.equals("Aged Brie")) {
-                    if (!items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (items[i].quality > 0) {
-                            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                                items[i].quality = items[i].quality - 1;
+            if (item.sellIn < 0) {
+                if (!item.name.equals("Aged Brie")) {
+                    if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                        if (item.quality > 0) {
+                            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                                item.quality = item.quality - 1;
                             }
                         }
                     } else {
-                        items[i].quality = items[i].quality - items[i].quality;
+                        item.quality = item.quality - item.quality;
                     }
                 } else {
-                    if (items[i].quality < 50) {
-                        items[i].quality = items[i].quality + 1;
+                    if (item.quality < 50) {
+                        item.quality = item.quality + 1;
                     }
                 }
             }

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -12,52 +12,56 @@ public class GildedRose {
 
     public void updateQuality() {
         for (Item item : items) {
-            if (!item.name.equals("Aged Brie")
-                    && !item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                if (item.quality > 0) {
-                    if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                        item.quality = item.quality - 1;
+            updateQualityFor(item);
+        }
+    }
+
+    private void updateQualityFor(Item item) {
+        if (!item.name.equals("Aged Brie")
+                && !item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+            if (item.quality > 0) {
+                if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                    item.quality = item.quality - 1;
+                }
+            }
+        } else {
+            if (item.quality < 50) {
+                item.quality = item.quality + 1;
+
+                if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                    if (item.sellIn < 11) {
+                        if (item.quality < 50) {
+                            item.quality = item.quality + 1;
+                        }
                     }
+
+                    if (item.sellIn < 6) {
+                        if (item.quality < 50) {
+                            item.quality = item.quality + 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+            item.sellIn = item.sellIn - 1;
+        }
+
+        if (item.sellIn < 0) {
+            if (!item.name.equals("Aged Brie")) {
+                if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                    if (item.quality > 0) {
+                        if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
+                            item.quality = item.quality - 1;
+                        }
+                    }
+                } else {
+                    item.quality = item.quality - item.quality;
                 }
             } else {
                 if (item.quality < 50) {
                     item.quality = item.quality + 1;
-
-                    if (item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (item.sellIn < 11) {
-                            if (item.quality < 50) {
-                                item.quality = item.quality + 1;
-                            }
-                        }
-
-                        if (item.sellIn < 6) {
-                            if (item.quality < 50) {
-                                item.quality = item.quality + 1;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                item.sellIn = item.sellIn - 1;
-            }
-
-            if (item.sellIn < 0) {
-                if (!item.name.equals("Aged Brie")) {
-                    if (!item.name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (item.quality > 0) {
-                            if (!item.name.equals("Sulfuras, Hand of Ragnaros")) {
-                                item.quality = item.quality - 1;
-                            }
-                        }
-                    } else {
-                        item.quality = item.quality - item.quality;
-                    }
-                } else {
-                    if (item.quality < 50) {
-                        item.quality = item.quality + 1;
-                    }
                 }
             }
         }

--- a/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/GildedRose.java
@@ -1,0 +1,65 @@
+package com.example.cleancoder.liftupconditionals;
+
+/**
+ * 출처: https://github.com/emilybache/GildedRose-Refactoring-Kata
+ */
+public class GildedRose {
+    Item[] items;
+
+    public GildedRose(Item[] items) {
+        this.items = items;
+    }
+
+    public void updateQuality() {
+        for (int i = 0; i < items.length; i++) {
+            if (!items[i].name.equals("Aged Brie")
+                    && !items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                if (items[i].quality > 0) {
+                    if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+                        items[i].quality = items[i].quality - 1;
+                    }
+                }
+            } else {
+                if (items[i].quality < 50) {
+                    items[i].quality = items[i].quality + 1;
+
+                    if (items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                        if (items[i].sellIn < 11) {
+                            if (items[i].quality < 50) {
+                                items[i].quality = items[i].quality + 1;
+                            }
+                        }
+
+                        if (items[i].sellIn < 6) {
+                            if (items[i].quality < 50) {
+                                items[i].quality = items[i].quality + 1;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+                items[i].sellIn = items[i].sellIn - 1;
+            }
+
+            if (items[i].sellIn < 0) {
+                if (!items[i].name.equals("Aged Brie")) {
+                    if (!items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                        if (items[i].quality > 0) {
+                            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+                                items[i].quality = items[i].quality - 1;
+                            }
+                        }
+                    } else {
+                        items[i].quality = items[i].quality - items[i].quality;
+                    }
+                } else {
+                    if (items[i].quality < 50) {
+                        items[i].quality = items[i].quality + 1;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/cleancoder/liftupconditionals/Item.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/Item.java
@@ -1,0 +1,20 @@
+package com.example.cleancoder.liftupconditionals;
+
+public class Item {
+    public String name;
+
+    public int sellIn;
+
+    public int quality;
+
+    public Item(String name, int sellIn, int quality) {
+        this.name = name;
+        this.sellIn = sellIn;
+        this.quality = quality;
+    }
+
+    @Override
+    public String toString() {
+        return this.name + ", " + this.sellIn + ", " + this.quality;
+    }
+}

--- a/src/main/java/com/example/cleancoder/liftupconditionals/Item.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/Item.java
@@ -7,10 +7,31 @@ public class Item {
 
     public int quality;
 
-    public Item(String name, int sellIn, int quality) {
+    protected Item(String name, int sellIn, int quality) {
         this.name = name;
         this.sellIn = sellIn;
         this.quality = quality;
+    }
+
+    public static Item of(String name, int sellIn, int quality) {
+        return switch (name) {
+            case "Sulfuras, Hand of Ragnaros" -> new Sulfuras(sellIn, quality);
+            case "Backstage passes to a TAFKAL80ETC concert" -> new Backsage(sellIn, quality);
+            case "Aged Brie" -> new AgedBrie(sellIn, quality);
+            default -> new Item(name, sellIn, quality);
+        };
+    }
+
+    protected void updateQuality() {
+        if (quality > 0) {
+            quality = quality - 1;
+        }
+
+        sellIn = sellIn - 1;
+
+        if (sellIn < 0 && quality > 0) {
+            quality = quality - 1;
+        }
     }
 
     @Override

--- a/src/main/java/com/example/cleancoder/liftupconditionals/Sulfuras.java
+++ b/src/main/java/com/example/cleancoder/liftupconditionals/Sulfuras.java
@@ -1,0 +1,11 @@
+package com.example.cleancoder.liftupconditionals;
+
+public class Sulfuras extends Item {
+    public Sulfuras(int sellIn, int quality) {
+        super("Sulfuras, Hand of Ragnaros", sellIn, quality);
+    }
+
+    @Override
+    protected void updateQuality() {
+    }
+}

--- a/src/test/java/com/example/cleancoder/liftupconditionals/GildedRoseTest.java
+++ b/src/test/java/com/example/cleancoder/liftupconditionals/GildedRoseTest.java
@@ -8,7 +8,7 @@ public class GildedRoseTest {
 
     @Test
     public void foo() {
-        Item[] items = new Item[] { new Item("foo", 0, 0) };
+        Item[] items = new Item[] {Item.of("foo", 0, 0)};
         GildedRose app = new GildedRose(items);
         app.updateQuality();
         assertThat(app.items[0].name).isEqualTo("foo");

--- a/src/test/java/com/example/cleancoder/liftupconditionals/GildedRoseTest.java
+++ b/src/test/java/com/example/cleancoder/liftupconditionals/GildedRoseTest.java
@@ -1,0 +1,17 @@
+package com.example.cleancoder.liftupconditionals;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class GildedRoseTest {
+
+    @Test
+    public void foo() {
+        Item[] items = new Item[] { new Item("foo", 0, 0) };
+        GildedRose app = new GildedRose(items);
+        app.updateQuality();
+        assertThat(app.items[0].name).isEqualTo("foo");
+    }
+
+}

--- a/src/test/java/com/example/cleancoder/liftupconditionals/TexttestFixture.java
+++ b/src/test/java/com/example/cleancoder/liftupconditionals/TexttestFixture.java
@@ -5,16 +5,16 @@ public class TexttestFixture {
         System.out.println("OMGHAI!");
 
         Item[] items = new Item[] {
-                new Item("+5 Dexterity Vest", 10, 20), //
-                new Item("Aged Brie", 2, 0), //
-                new Item("Elixir of the Mongoose", 5, 7), //
-                new Item("Sulfuras, Hand of Ragnaros", 0, 80), //
-                new Item("Sulfuras, Hand of Ragnaros", -1, 80),
-                new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
-                new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
-                new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+                Item.of("+5 Dexterity Vest", 10, 20), //
+                Item.of("Aged Brie", 2, 0), //
+                Item.of("Elixir of the Mongoose", 5, 7), //
+                Item.of("Sulfuras, Hand of Ragnaros", 0, 80), //
+                Item.of("Sulfuras, Hand of Ragnaros", -1, 80),
+                Item.of("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+                Item.of("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+                Item.of("Backstage passes to a TAFKAL80ETC concert", 5, 49),
                 // this conjured item does not work properly yet
-                new Item("Conjured Mana Cake", 3, 6) };
+                Item.of("Conjured Mana Cake", 3, 6)};
 
         GildedRose app = new GildedRose(items);
 

--- a/src/test/java/com/example/cleancoder/liftupconditionals/TexttestFixture.java
+++ b/src/test/java/com/example/cleancoder/liftupconditionals/TexttestFixture.java
@@ -1,0 +1,36 @@
+package com.example.cleancoder.liftupconditionals;
+
+public class TexttestFixture {
+    public static void main(String[] args) {
+        System.out.println("OMGHAI!");
+
+        Item[] items = new Item[] {
+                new Item("+5 Dexterity Vest", 10, 20), //
+                new Item("Aged Brie", 2, 0), //
+                new Item("Elixir of the Mongoose", 5, 7), //
+                new Item("Sulfuras, Hand of Ragnaros", 0, 80), //
+                new Item("Sulfuras, Hand of Ragnaros", -1, 80),
+                new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20),
+                new Item("Backstage passes to a TAFKAL80ETC concert", 10, 49),
+                new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49),
+                // this conjured item does not work properly yet
+                new Item("Conjured Mana Cake", 3, 6) };
+
+        GildedRose app = new GildedRose(items);
+
+        int days = 2;
+        if (args.length > 0) {
+            days = Integer.parseInt(args[0]) + 1;
+        }
+
+        for (int i = 0; i < days; i++) {
+            System.out.println("-------- day " + i + " --------");
+            System.out.println("name, sellIn, quality");
+            for (Item item : items) {
+                System.out.println(item);
+            }
+            System.out.println();
+            app.updateQuality();
+        }
+    }
+}


### PR DESCRIPTION
 depth가 깊은 if 조건문이 switch문에서 서브 클래스로 변화되는 과정이 인상깊었던 리팩터링

- 원본 예제 저장소: https://github.com/emilybache/GildedRose-Refactoring-Kata
- `Lift Up Conditionals` : 길고 복잡한 조건문을 조작하여 특정 조건과 관련된 코드 블록을 그룹핑하는 기법
  - 메소드 추출 
  - if else 조건문 감싸기 
  - 메소드 인라인
  - 불필요한 if 조건문 소거
  - switch문 변경 후 다형성 적용
